### PR TITLE
Report kenhys as the original finder of #99 (2017-12.csv)

### DIFF
--- a/upstream-feedback/2017-12.csv
+++ b/upstream-feedback/2017-12.csv
@@ -89,4 +89,5 @@
 2017-12-26,okkez,fluent/fluentd,patch,https://github.com/fluent/fluentd/pull/1802
 2017-12-26,okkez,fluent/fluentd-docs,patch,https://github.com/fluent/fluentd-docs/pull/399
 2017-12-28,fujimotos,lestrrat/go-file-rotatelogs,patch,https://github.com/lestrrat/go-file-rotatelogs/pull/12
+2017-12-28,kenhys,lestrrat/go-file-rotatelogs,find,https://github.com/lestrrat/go-file-rotatelogs/pull/12
 2017-12-28,okkez,fluent/fluentd-docs,patch,https://github.com/fluent/fluentd-docs/pull/401


### PR DESCRIPTION
This patch adds the following line to 2017-12.csv: 

`2017-12-28,kenhys,lestrrat/go-file-rotatelogs,find,https://github.com/lestrrat/go-file-rotatelogs/pull/12`

For some reasons, I cannot modify this file due to a permission error.